### PR TITLE
Fix monitor commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Create a single-file bundle at `dist/node/viciious.js` by running:
 
     $ npm run build-node
 
-You can now run  the emulator with the command:
+You can now run the emulator with the command:
 
 ` $ node dist/node/viciious.js <someprogram>`
 
@@ -95,7 +95,7 @@ You can omit the program argument, in which case the emulator will boot to Basic
 You can also build to the bundle and run it (to Basic) with a single command, using:
 
     $ npm run run-node
-    
+
 #### Running the automated tests
 
 The repo includes a build of Wolfgang Lorenz’s excellent emulator test suite. Run it with the command:

--- a/src/host/webFrontEnd/template.ejs
+++ b/src/host/webFrontEnd/template.ejs
@@ -392,7 +392,7 @@
                 </div>
 
                 <div>
-                  Awesome SID music by Jason Page
+                  An awesome SID tune by Jason Page
                 </div>
 
               </div>

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -93,7 +93,7 @@ function installCli() {
           c64.cpu.showState();
         }
         catch (r) {}
-        return c64.cpu.state;
+        return c64.cpu.getState();
       }
     },
     {
@@ -137,21 +137,21 @@ function installCli() {
 
 async function singleStep(steps = 1) {
   while (steps--) {
-    const initialPc = c64.cpu.state.pc;
+    const initialPc = c64.cpu.getState().pc;
     await runloop.run({
-      tick: () => c64.cpu.state.pc !== initialPc
+      tick: () => c64.cpu.getState().pc !== initialPc
     });
     c64.cpu.showState();
   }
 }
 
-async function untilPc(pc) {
+async function untilPc(pc, fast) {
   if (pc === undefined) {
     console.error("Missing argument: PC address");
     return;
   }
 
-  await runloop.untilPc(pc);
+  await runloop.untilPc(pc, fast);
   c64.cpu.showState();
 }
 

--- a/src/target/cpu.js
+++ b/src/target/cpu.js
@@ -1891,9 +1891,9 @@ function op_BIT_tmp_void() {
 function op_ANE_tmp_void() {
   // Quasi-op: "XAA" (†4, which is inaccurate), "ANE" (†1)
 
-  // †1 describes how this 0x11 constant can altenatively be 0x10, 0x01 or 0x00
-  // depending on residual charge on the open bus. The 0x11 used here is the
-  // value expected by the Lorenz aneb test.
+  // †1 describes how this 0x11 constant can alternatively be 0x10, 0x01,
+  // or 0x00 depending on residual charge on the open bus. The 0x11 used here
+  // is the value expected by the Lorenz aneb test.
   state.a = ((state.a & 0x11 & state.x) | ( 0xee & state.x)) & state.tmp;
   state.z = state.a ? 0 : 1;
   state.n = (state.a & 0x80) ? 1 : 0;

--- a/src/target/runloop.js
+++ b/src/target/runloop.js
@@ -196,10 +196,13 @@ async function untilPc(pc, fast = false) {
     tick: () => regs.pc !== pc,
   });
 
-  return run({
+  const profile = {
     tick: () => regs.pc === pc,
-    fps: fast ? Infinity : undefined,
-  });
+  };
+
+  if (fast) profile.fps = Infinity;
+
+  return run(profile);
 }
 
 function type(str) {


### PR DESCRIPTION
Fixes
- single step (monitor `s`) broken from a much earlier refactor
- show registers (monitor `r`), likewise: printing but not returning
- runloop ignoring `fast` parameter from monitor `u`